### PR TITLE
ISSUE-1 - Add dotfiles

### DIFF
--- a/.github/workflows/lint-codebase.yml
+++ b/.github/workflows/lint-codebase.yml
@@ -4,9 +4,6 @@ on:
   pull_request:
     paths:
       - '**.swift'
-  push:
-    paths:
-      - '**.swift'
 
 jobs:
   swiftlint:

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 xcuserdata/
 DerivedData/
 .swiftpm/xcode
+.swiftlint.yml

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule ".dotfiles"]
+	path = .dotfiles
+	url = https://github.com/GetAutomaApp/dotfiles

--- a/Package.swift
+++ b/Package.swift
@@ -17,10 +17,7 @@ let package = Package(
             name: "TwitterAPIKit",
             targets: ["TwitterAPIKit"]),
     ],
-    dependencies: [
-        // Dependencies declare other packages that this package depends on.
-        // .package(url: /* package url */, from: "1.0.0"),
-    ],
+    dependencies: [],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
         // Targets can depend on other targets in this package, and on products in packages this package depends on.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "twitterapikit",
+  "version": "1.0.0",
+  "description": "Swift library for the Twitter API v1 and v2 🍷",
+  "main": "index.js",
+  "scripts": {
+    "config": "./.dotfiles/config.sh",
+    "install:swiftlint": "brew install swiftlint",
+    "install:swiftformat": "brew install swiftformat",
+    "install:all": "npx npm-run-all --sequential install:swiftlint install:swiftformat config",
+    "format": "swiftformat .",
+    "lint": "swiftlint --config=.swiftlint.yml .",
+    "update:submmdules": "git submodule foreach --recursive 'branch=$(git remote show origin | awk \"/HEAD branch/ {print \\$NF}\"); git checkout $branch && git pull origin $branch' && CHANGED=$(git status --porcelain | grep '^ M \\.dotfiles' || true) && if [ -n \"$CHANGED\" ]; then npm run config; fi && git add -A && git commit -m \"chore: update submodules\" || echo 'No changes to commit'"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/GetAutomaApp/TwitterAPIKit.git"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/GetAutomaApp/TwitterAPIKit/issues"
+  },
+  "homepage": "https://github.com/GetAutomaApp/TwitterAPIKit#readme"
+}


### PR DESCRIPTION
# Reason

This repo after being forked wasn't touched a lot, but some of the code decisions we make in here might not be synced with the rest of our repositories. This PR only implements whats needed to start running swiftlint & swiftformat locally!

# Tech Details List

- Adds dotfiles
- Ignores .swiftlint.yml file (symlinked via the .dotfiles repo)
- Adds all the required commands to update submodules & configure

**Links:**

[ISSUE-1](https://github.com/GetAutomaApp/AutomaInfraCore/issues/1)
closes/resolves #1

# Testing

**Steps:**
1. Ensure that the linting passes (might fail if there is a violation)
2. Ensure you can run linting locally & the install:all command works
3. Ensure the commands to update the submodules also works

